### PR TITLE
Article indexes as u64 instead of u32

### DIFF
--- a/examples/overviews.rs
+++ b/examples/overviews.rs
@@ -33,9 +33,9 @@ struct Opt {
 enum Cmd {
     Xover {
         #[structopt(short, long)]
-        low: u32,
+        low: u64,
         #[structopt(short, long)]
-        high: u32,
+        high: u64,
         #[structopt(short, long, parse(from_os_str))]
         out: Option<PathBuf>,
     },

--- a/examples/xfeature_compression.rs
+++ b/examples/xfeature_compression.rs
@@ -1,5 +1,6 @@
 use brokaw::types::command::{XFeatureCompress, XOver};
 
+use brokaw::types::ArticleNumber;
 use brokaw::*;
 use log::*;
 use structopt::StructOpt;
@@ -16,7 +17,7 @@ struct Opt {
     group: String,
     /// The number of headers to retrieve
     #[structopt(long, short)]
-    num_headers: u32,
+    num_headers: ArticleNumber,
     #[structopt(long)]
     username: String,
     #[structopt(long)]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -20,8 +20,8 @@ pub mod response_code;
 /// The number of an article relative to a specific Newsgroup
 ///
 /// Per [RFC 3977](https://tools.ietf.org/html/rfc3977#section-6) article numbers should fit within
-/// 31-bits.
-pub type ArticleNumber = u32;
+/// 31-bits but has been surpassed since.
+pub type ArticleNumber = u64;
 
 /// Re-exports of traits and response types
 pub mod prelude {

--- a/src/types/response/group.rs
+++ b/src/types/response/group.rs
@@ -8,11 +8,11 @@ use crate::types::response::util::{err_if_not_kind, parse_field};
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Group {
     /// The _estimated_ number of articles in the group
-    pub number: u32,
+    pub number: ArticleNumber,
     /// The lowest reported article number
-    pub low: u32,
+    pub low: ArticleNumber,
     /// The highest reported article number
-    pub high: u32,
+    pub high: ArticleNumber,
     /// The name of the group
     pub name: String,
 }

--- a/src/types/response/util.rs
+++ b/src/types/response/util.rs
@@ -37,7 +37,7 @@ pub(crate) fn process_article_first_line(resp: &RawResponse) -> Result<(ArticleN
 
     iter.next(); // skip response code since we already parsed it
 
-    let number: u32 = parse_field(&mut iter, "article-number")?;
+    let number: ArticleNumber = parse_field(&mut iter, "article-number")?;
     // https://tools.ietf.org/html/rfc3977#section-9.8
     let message_id: String = parse_field(&mut iter, "message-id")?;
 


### PR DESCRIPTION
The RFC specifies that article counts fit in a signed int, but the limit
has been surpassed in some newsgroups, and servers are returning numbers
that would fit in a u64.