### PR TITLE
Add command newgroups

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -105,6 +105,31 @@ impl NntpClient {
         Ok(resp)
     }
 
+    /// List new newsgroups created since a specific date and time
+    ///
+    /// # Arguments
+    ///
+    /// * `date` - The date from which to list new newsgroups
+    /// * `time` - The time from which to list new newsgroups
+    /// * `distributions` - Optional distributions to include
+    ///
+    /// # Returns
+    ///
+    /// A result containing the raw response from the server
+    pub fn newgroups(
+        &mut self,
+        date: &str,
+        time: &str,
+        distributions: Option<&str>,
+    ) -> Result<RawResponse> {
+        let command = cmd::NewGroups {
+            date: date.to_string(),
+            time: time.to_string(),
+            distributions: distributions.map(|d| d.to_string()),
+        };
+        self.command(command)
+    }
+
     /// Get the currently selected group
     pub fn config(&self) -> &ClientConfig {
         &self.config

--- a/src/types/command/rfc3977.rs
+++ b/src/types/command/rfc3977.rs
@@ -254,7 +254,32 @@ impl fmt::Display for ModeReader {
 
 impl NntpCommand for ModeReader {}
 
-// TODO(commands) implement NEWGROUPS
+// implement NEWGROUPS
+
+/// List newsgroups created since a specific date
+#[derive(Clone, Debug)]
+pub struct NewGroups {
+    /// The date from which to list newsgroups
+    pub date: String,
+    /// the time from which to list newsgroups
+    pub time: String,
+    /// Optional distributions to include
+    pub distributions: Option<String>,
+}
+
+impl fmt::Display for NewGroups {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "NEWGROUPS {} {} {}",
+            self.date,
+            self.time,
+            self.distributions.as_deref().unwrap_or("")
+        )
+    }
+}
+
+impl NntpCommand for NewGroups {}
 
 // TODO(commands) implement NEWNEWS
 

--- a/src/types/command/rfc3977.rs
+++ b/src/types/command/rfc3977.rs
@@ -269,13 +269,10 @@ pub struct NewGroups {
 
 impl fmt::Display for NewGroups {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "NEWGROUPS {} {} {}",
-            self.date,
-            self.time,
-            self.distributions.as_deref().unwrap_or("")
-        )
+        match &self.distributions {
+            Some(dist) => write!(f, "NEWGROUPS {} {} {}", self.date, self.time, dist),
+            None => write!(f, "NEWGROUPS {} {}", self.date, self.time),
+        }
     }
 }
 


### PR DESCRIPTION
I am using the Brokaw library to write a TUI Usenet client in rust and I need the "newgroups" command added, so forked and added the changes, works for me locally, but do please review, I am fairly new with rust. I am testing against our current usenet server at news.hispagatos.org